### PR TITLE
typo on lib/microsoft_kiota_authentication_oauth/oauth_access_token_provider.rb

### DIFF
--- a/lib/microsoft_kiota_authentication_oauth/oauth_access_token_provider.rb
+++ b/lib/microsoft_kiota_authentication_oauth/oauth_access_token_provider.rb
@@ -29,7 +29,7 @@ module MicrosoftKiotaAuthenticationOAuth
       @cached_token = nil
 
       @host_validator = if allowed_hosts.nil? || allowed_hosts.size.zero?
-                          MicrsoftKiotaAbstractions::AllowedHostsValidator.new(['graph.microsoft.com', 'graph.microsoft.us', 'dod-graph.microsoft.us',
+                          MicrosoftKiotaAbstractions::AllowedHostsValidator.new(['graph.microsoft.com', 'graph.microsoft.us', 'dod-graph.microsoft.us',
                                                      'graph.microsoft.de', 'microsoftgraph.chinacloudapi.cn',
                                                      'canary.graph.microsoft.com'])
                         else


### PR DESCRIPTION
Hi there!

I was following the tutorial on https://github.com/microsoftgraph/msgraph-sdk-ruby#21-register-your-application and I got this error:

```uninitialized constant MicrosoftKiotaAuthenticationOAuth::OAuthAccessTokenProvider::MicrsoftKiotaAbstractions (NameError)```

I think there is a typo here: https://github.com/microsoft/kiota-authentication-oauth-ruby/blob/434bae54b86067da6adcf06048965fb22abba204/lib/microsoft_kiota_authentication_oauth/oauth_access_token_provider.rb#L32

Thanks for having a look!